### PR TITLE
Convert extensions to UTF-8.

### DIFF
--- a/Consent.i7x
+++ b/Consent.i7x
@@ -57,7 +57,7 @@ This can be as detailed as needed, including references to scenes and specific t
 
 Section: Granting consent
 
-Consent is granted in a similar way that persuasion is defined (see ง12.4 for details), using the Consent rulebook. Consent can be given or denied both for specific actions and/or persons, or in a broader sense with the terms someone and something. Example A shows how to give a specific consent; for a very general rule (that undoes everything we try to accomplish here, and as such is only good for testing or as an example) we could use the following:
+Consent is granted in a similar way that persuasion is defined (see ยง12.4 for details), using the Consent rulebook. Consent can be given or denied both for specific actions and/or persons, or in a broader sense with the terms someone and something. Example A shows how to give a specific consent; for a very general rule (that undoes everything we try to accomplish here, and as such is only good for testing or as an example) we could use the following:
 
 *:
 	Consent rule for an actor doing something to someone: Consent given.
@@ -71,11 +71,11 @@ Only actions that are defined to require consent (see above) will be checked, bu
 
 Section: Failure messages
 
-Actions stopped due to denied consent is handled similarly to failed persuasion (see ง12.5 for details), using the Consent denied for rulebook. Example A shows how to give a specific failure message. It's important to use the "instead" keyword here, otherwise the default failure message will be printed as well.
+Actions stopped due to denied consent is handled similarly to failed persuasion (see ยง12.5 for details), using the Consent denied for rulebook. Example A shows how to give a specific failure message. It's important to use the "instead" keyword here, otherwise the default failure message will be printed as well.
 
 Chapter: Technical Notes
 
-The default failure message can be altered by altering the consent seeking rule response (A), detailed in ง14.11:
+The default failure message can be altered by altering the consent seeking rule response (A), detailed in ยง14.11:
 
 *:
 	The consent seeking rule response (A) is "That would be rude."

--- a/Erotic Story Actions.i7x
+++ b/Erotic Story Actions.i7x
@@ -771,7 +771,7 @@ Technically there's also several different ways to change the response of an act
 	After kissing Helena's feet, say "You gently kiss her feet."
 	After touching Helena's feet, say "You fondle Helena's feet[if sneakers are worn by Helena] through her shoes[end if]."
 
-For a final twist, we might want to swap messages when a command is repeated. This can eithe be done by using [one of] inside a text, as described in ง5.7 - Text with random alternatives. For longer, more complex alternatives, it's better to use the tecniques described in ง7.16 - Repeated Actions, an example of which is shown below. Note that the action described can be either specific or general.
+For a final twist, we might want to swap messages when a command is repeated. This can eithe be done by using [one of] inside a text, as described in ยง5.7 - Text with random alternatives. For longer, more complex alternatives, it's better to use the tecniques described in ยง7.16 - Repeated Actions, an example of which is shown below. Note that the action described can be either specific or general.
 
 	After waiting for the first time, say "Time passes slowly..."
 	After waiting for third time, say "Getting impatient, are we?"


### PR DESCRIPTION
A couple of files had some latin-1 characters, which the Linux IDE
couldn't open for editing, at least on locales that use UTF-8. Latin-1
is mostly compatible with UTF-8, so this only changes a couple
characters.
