### PR TITLE
Consent, Stimulation and DACS fixes

### DIFF
--- a/Documentation.txt
+++ b/Documentation.txt
@@ -6,11 +6,11 @@ Section 1.1 - Documentation Overview
 Section 1.2 - Responses and Descriptions
 Section 1.3 - Action Overview
 Section 1.4 - Layering and Templates
-	Example A
+	Example A - Templates
 Section 1.5 - Discrete Arousal-based Consent and Stimulation
-	Example B
-Section 1.6 - Character Behavior
-	Example C
+	Example B - DACS
+Section 1.6 - Character Agency
+	Example C - Agency
 Section 1.7 - Version History
 Section 1.8 - Contact Info
 Section 1.9 - Acknowledgments
@@ -26,6 +26,7 @@ Section 3.1 - Kinds and Templates
 Section 3.2 - Access and Visibility
 Section 3.3 - Manipulating Garments
 Section 3.4 - Customization
+	Example D - Customization
 
 Chapter 4 - Descriptions in Detail
 Section 4.1 - Body Parts
@@ -36,8 +37,11 @@ Section 4.4 - Responses
 Chapter 5 - NPCs
 Section 5.1 - Consent and Persusasion
 Section 5.2 - Agency
+	Example C - Agency
 Section 5.3 - Conversation
+	Example E - Dialogue
 Section 5.4 - Discrete Arousal-based Consent and Stimulation
+	Example B - DACS
 
 Chapter 6 - Support Functions
 Section 6.1 - Debug Functions
@@ -51,13 +55,14 @@ Section - Setting and Characters
 Section - Introduction to Inform
 Section - Geography (Locations)
 Section - Storyfile Layout (Organizing Inform)
+Section - Testing
 Section - Items
 Section - Programming Inform
 Section - Chronology (Scenes)
-Section - Descriptions
+Section - Character Facades
 Section - Sex Scenes
 Section - Actions, Continued
-Section - Agency
+Section - Character Depth
 Section - Mechanics
 
 Chapter 8 - Technical Reference
@@ -80,8 +85,7 @@ B: DACS
 C: Agency (***): Intelligent Agency - 
 D (***): Customization: A Furry Tale - How to create custom body parts.
 	Complete
-
-
+E: Dialogue
 
 
 	
@@ -295,7 +299,7 @@ Example B shows a simple DACS setup with some customizations.
 
 (**): See 'Anatomy of a Sex Scene', by ExLibris. http://overanalysingaif.blogspot.no/2010/12/anatomy-of-sex-scene.html
 
-Section 1.6 - Character Behavior
+Section 1.6 - Character Agency
 
 A recurring difficulty in person-oriented IF, which most AIF are, is how to make people seem lifelike.
 This problem manifests in several way, from the simple task of writing 'idle'-messages when the actor is not doing anything, to actors who roam around the map either randomly or goal oriented.
@@ -307,7 +311,7 @@ Agency is a term from philosophy which relates to an actor's capacity to act in 
 From the frustrations we can infer that a NPC has three different modes of agency that require different treatment:
 At the most basic stage, a NPC without a goal might want to print a randomized text message ('idle') to show that they aren't just static scenery.
 For characters that have a goal, we want to distinguish between planned and urgent agency, with the difference being that 'normal' planned agency will be delayed by player interactions while urgent agency being executed regardless.
-To facilitate this, the extension introduces a new stage in the turn processing rules, called the agency stage, where we consult the urgent, planned and idle agency rules for agency-enabled persons.
+To facilitate this, the extension introduces a new stage in the turn sequence rules, called the agency stage, where we consult the urgent, planned and idle agency rules for agency-enabled persons.
 
 The later chapter on NPCs covers this topic in detail, and Example C shows some sample interactive actors.
 
@@ -354,12 +358,13 @@ Section 2.1 - Limiting Factors
 It's unrealistic (and rather boring) to expect that every erotic action would succeed in every occasion.
 The actions go through a similar set of checks (with some exceptions) to verify that the action is feasible:
 
+[TODO: Rewrite these to not all start with 'the']
 	The body part isn't part of the actor. Exceptions: touching/rubbing/spanking/dancing. Fucking is also a special case.
 	The noun is the correct type (person/body part); some action tries to redirect to a noun of the correct type.
 	The noun supports the action, through the adjectives listed below.
 	The clothing of the person allows access to the noun
 	The action is decent enough for the location
-	The owner of the noun consents
+	The person related to the noun consents
 
 The check to se whether the noun supports an action is done through a set of adjectives, which by default are defined for body parts.
 These adjectives are named according to the related action, and the default negated form is the un- prefix.
@@ -399,6 +404,7 @@ Actions applying to body parts or persons are also compared to the threshold, an
 	The touching decency is initially immodest.
 
 The last check is to see if all involved parties consent to the action, which is a separate rulebook described in section 5.1.
+If no consent rules are written and the DACS system is not enabled, the default consent rule will deny consent and state the uninterested response for the person.
 It's possible to use the builtin (optional) Discrete Arousal-based Consent and Stimulation system (DACS), which is described in Section 5.4.
 
 As mentioned earlier, the actions are split into those who expects a person as the noun, and those that expect a body part.
@@ -715,6 +721,7 @@ Randomly alternating text is also very simple, using the 'one of' constructs des
 The following short example highlights some of the these tricks:
 
 *:
+	A Boring Room is a room.
 	After waiting, say "[first time]This will only be printed the first time. [only]You [one of]wait[or]linger[or]sulk[or]skulk[then at random]."
 	After waiting the second time, say "This is getting boring."
 	After waiting for four turns, say "You sneeze. Whoops."
@@ -760,30 +767,78 @@ Asking other characters to perform actions is well supported by Inform 7, and an
 While chapters 12.3 to 12.5 cover persuasion in detail, a quick recap is called for.
 Whenever the player asks another character to do something in the form of MARY, KISS ME, Inform consults the persuasion rules to see if the action should be attempted.
 The author is then free to devise arbitrarily complex rules for determining if the actor should attempt the given action.
+If no consent rules are written and the DACS system is not enabled, the default consent rule will deny consent and state the uninterested response for the person.
 
 The approach works well for when the actor is the main participant in an action, but it doesn't really handle interactions with multiple parties.
 Taking kissing as an example, what is really the difference between MARY, KISS ME and KISS MARY?
 The first would be governed by the persuasion rules but the second would succeed unless the author intervened with an instead rule.
-To make it easier for the author to control when a character consents to being a part of such actions we have created the consent rules along a similar vein as the persuasion rules.
-All of the actions in this extension goes through this rulebook, even the single actor actions such as wearing and taking off garments.
+[TODO: Grant persuasion based on consent?]
+To make it easier for the author to control when a character consents to being a part of such actions the consent rules are processed in a similar fashion as the persuasion rules.
+The Discrete-Arousal-based Consent and Stimulation (DACS) system included with the extension provides an option to grant consent based on the current arousal of the character.
+Using DACS to handle consent is explained in more detail in section 5.4, while this section is more focused on how to write custom consent rules.
 
+All of the actions in this extension goes through the consent rulebook, including the single actor actions such as wearing and taking off garments.
 Writing consent rules are done in a similar way as for persuasion, but instead of the outcomes 'persuasion succeeds' or 'persuasion fails' we have 'give consent' and 'deny consent'.
 The default outcome of a rule is to deny consent, but it's also possible to 'make no decision' to give control back to the rulebook for further processing.
 The rulebook includes a 'default consent rule' that will be consulted if no other rule is found, which will stop the action with a generic 'They aren't consenting to that (action)'.
 Currently there is also a check that the persons involved in the action are in each other's love interests list-property, but this is something that might be revised.
 [TODO: Revise this]
 
-The extension also includes the Discrete-Arousal-based Consent and Stimulation (DACS) system that grants consent based on the current arousal.
-This is explained in more detail in Section 5.4.
+We previously mentioned (in Section 4.4 - Responses) that the scene function of Inform should be to control sex scenes.
+It's also possible to split one sex scene into several scenes, to allow consent for various new actions as the sex scene progresses.
+We can then use the 'during' clause when writing rules to tie them to that scene, which allows for the consent rule itself to be very broad.
+Below is a minimal example that illustrates this:
+
+*:
+	Include Erotic Storytelling by Fictitious Frode.
+
+	Bedroom is a room. The decency threshold of Bedroom is indecent.
+	Adam is a man in Bedroom. The player is Adam.
+	Beatrice is a woman in Bedroom.
+	A penis is a part of every man.
+	A vagina is a part of every woman.
+
+	Beatrice's Encounter is a scene. Beatrice's Encounter begins when the player is in Bedroom for the fifth turn. [* This is a bug in 6M62 that makes the scene trigger a turn early]
+	When Beatrice's Encounter begins, say "'Oh, all right then, let's get this over with,' Beatrice sighs."
+	When Beatrice's Encounter begins, add Adam to the Love Interests of Beatrice. [TODO: Make this obsolete]
+	Consent rule for doing something to Beatrice during Beatrice's Encounter: Give consent.
+	Consent rule for doing something to something enclosed by Beatrice during Beatrice's Encounter: Give consent.
+	Consent rule for fucking something enclosed by Beatrice with something during Beatrice's Encounter: Give consent.
+	
+	Test me with "kiss Beatrice / lick Beatrice / fuck Beatrice / z / kiss Beatrice / lick Beatrice / fuck Beatrice".
+
+[You can also use the action groupings that DACS uses]
 
 Section 5.2 - Agency
 
-Perhaps the 
+One of the most important ways to distinguish characters is to give them the agency to act on their own.
+While characters in traditional AIF is mainly stationary, it's easy to use Inform's every turn rules to make them act on their own.
+The mechanisms for providing agency in this extension is based on the every turn rules with some extra scaffolding to make it easier to control interactions between multiple actors and the player.
+
+Agency is implemented as a new stage in the turn sequence rules, similar to how the player's action and the every turn rules are processed.
+We divide an actors agency into three categories that must be treated differently, each of which get their own rulebook that the agency stage rule will process as appropriate.
+
+
+[From intro:
+From the frustrations we can infer that a NPC has three different modes of agency that require different treatment:
+At the most basic stage, a NPC without a goal might want to print a randomized text message ('idle') to show that they aren't just static scenery.
+For characters that have a goal, we want to distinguish between planned and urgent agency, with the difference being that 'normal' planned agency will be delayed by player interactions while urgent agency being executed regardless.
+To facilitate this, the extension introduces a new stage in the turn processing rules, called the agency stage, where we consult the urgent, planned and idle agency rules for agency-enabled persons.
+]
+
+[The difference between the agency rulebooks]
+
+[How the agency rulebooks are processed]
+
+[Interactions between several actors, and with every turn rules]
+
+
+
 
 A person can be occupied or unoccupied. A person is usually unoccupied.
-A person can be behavior-enabled or behavior-disabled. A person is usually behavior-disabled.
+A person can be agency-enabled or agency-disabled. A person is usually agency-disabled.
 A person has a number called priority.
-A person has some text called the behavior state description.
+A person has some text called the agency state description.
 
 
 
@@ -938,7 +993,7 @@ Persons get more changes, see also decency above.
 	Orgasmic Attemps: The number of times the ORGASMS phrase has been called since the last orgasm. Used to calculate the success rate for ORGASMS.
 	Priority: Used by the agency rules to determine the acting order.
 	Unaroused Response: Issued by the DACS templates when the person is not interested in the action, due to the current arousal of the person not being high enough. Defaults to "'Not yet,' [printed name] says softly."
-	Uninterested Response: Issued by the DACS templates when the person is not interested in the action, either due to unattainable arousal threshold or lack of love interest. Defaults to "'That's not going to happen,' [printed name] says cooly."
+	Uninterested Response: Issued by the the consent rules when the default consent rule denies consent. Also used by the DACS templates and issued when the person is not interested in the action, either due to unattainable arousal threshold or lack of love interest. Defaults to "'That's not going to happen,' [printed name] says cooly."
 
 Persons also have quite a few arousals for use with DACS; How these work are described in more detail earlier in the arousal section, but the default values are listed here:
 

--- a/Erotic Storytelling.i7x
+++ b/Erotic Storytelling.i7x
@@ -1720,9 +1720,11 @@ We create a new rulebook, with outcomes stimulated and unstimulated, and default
 The stimulation rules is a rulebook.
 The stimulation rules have outcomes stimulated (success - the default) and unstimulated (failure).
 
-[We also create a seperate rulebook to pack the default rules into, that we only want called explicitly.]
-The default-stimulation rules is a rulebook.
-The default-stimulation rules have outcomes stimulated (success - the default) and unstimulated (failure).
+[This default stimulation rule is as generic as possible, and will be executed last.
+It's main purpose is to stop the execution of any rule defined to be after it.]
+The default stimulation rule is listed last in the stimulation rules.
+A stimulation rule (this is the default stimulation rule):
+	Unstimulated;
 
 Part 3.1.2 - Consent
 
@@ -1733,25 +1735,25 @@ The consent rules is a rulebook.
 The consent rules have outcomes give consent (success) and deny consent (failure - the default).
 
 [This default consent rule is as generic as possible, and will be executed last.]
+The default consent rule is listed last in the consent rules.
 A consent rule (this is the default consent rule):
 	[Check consent for the actor first; we assume that the player always consent.]
 	If the actor is not the player:
-		Say "[The actor] [aren't] consenting to that ([current action])." (A);
+		Say the uninterested response of the actor;
+[		Say "[The actor] [aren't] consenting to that ([current action])." (A);]
 		Deny consent;
 	[Check consent for the noun directly]
 	If the noun is a person:
 		If the noun is not the player:
-			Say "[The noun] [aren't] consenting to that ([current action])." (B);
+			Say the uninterested response of the noun;
+[			Say "[The noun] [aren't] consenting to that ([current action])." (B);]
 			Deny consent;
 	Else if the noun is a body part:
 		Let P be the holder of the noun;
 		If P is not the player:
-			Say "[The P] [aren't] consenting to that ([current action])." (C);
+			Say the uninterested response of P;
+[			Say "[The P] [aren't] consenting to that ([current action])." (C);]
 			Deny consent;
-
-[We also create a seperate rulebook to pack the default rules into, that we only want called explicitly.]
-The default-consent rules is a rulebook.
-The default-consent rules have outcomes give consent (success - the default) and deny consent (failure).
 
 Part 3.1.3 - Properties
 
@@ -3330,6 +3332,9 @@ Book 5.2 - Discrete Arousal-based Consent and Stimulation
 This books deals with integrating the discrete arousals into the stimulation and consent framework of the actions, to create a basis system that grants consent based on arousal. It's separated into it's own part in order to make it easier to excise it if needed, like if the author wants to use a numerical arousal system.
 The underlying parts deals with responses of the actors, action integration and custom values for the templated body parts.]
 
+[We create a use-mode for enabling DACS:]
+Use DACS translates as (- Constant ENABLE_DACS; -). 
+
 Part 5.2.1 - Responses
 
 [Status: Complete
@@ -3356,6 +3361,15 @@ Stimulation is similarly handled, being increased one level up to the cap for th
 
 Additionally, there's a check to see if the two actors want to interact with each other, which is used as a default deny rule.]
 
+[DEPRECATED: We can avoid these seperate rulebooks by stashing the rules last, so the default rule will be processed before them.
+We also create a seperate rulebook to pack the default rules into, that we only want called explicitly.
+The default-consent rules is a rulebook.
+The default-consent rules have outcomes give consent (success - the default) and deny consent (failure).
+We also create a seperate rulebook to pack the default rules into, that we only want called explicitly.
+The default-stimulation rules is a rulebook.
+The default-stimulation rules have outcomes stimulated (success - the default) and unstimulated (failure).
+]
+
 Chapter 5.2.2a - General Requirements
 
 [A person has a list of other actors they are willing to engage with. Make sure that all people potentially involved are listed in each others love interests.
@@ -3363,9 +3377,8 @@ If the interactor is listed, make no decision in order to allow other rules to b
 
 A person has a list of people called love interests.
 
-[Always check the love interests first.]
-The love interest consent rule is listed first in the consent rules.
-
+[Love interests should only be checked by the DACS rules.]
+The love interest consent rule is listed after the default consent rule in the consent rules.
 A consent rule (this is the love interest consent rule):
 	[Determine which people are involved]
 	Let first person be the actor;[TODO: This must be redone]
@@ -3419,7 +3432,8 @@ A garment has an arousal called the clothing threshold. The clothing threshold o
 
 Section - Wearing
 
-A default-consent rule (this is the dressing consent rule):
+The dressing consent rule is listed after the default consent rule in the consent rules.
+A consent rule (this is the dressing consent rule):
 	If the noun is a garment (called G):
 		Unless the actor is the player:
 			If the clothing threshold of the actor is the unattainable arousal
@@ -3432,11 +3446,15 @@ A default-consent rule (this is the dressing consent rule):
 				Deny consent;
 	Give consent;
 
-A consent rule for an actor wearing something (this is the dressing default consent rule): Abide by the dressing consent rule;
+[We can skip abide by the love interest consent rule because only the actor will be wearing clothes]
+A consent rule for an actor wearing something (this is the dressing default consent rule):
+	Unless DACS option is active, make no decision;
+	Abide by the dressing consent rule;
 
 Section - Worn Garments
 
-A default-consent rule (this is the undressing consent rule):
+The worn garment consent rule is listed after the default consent rule in the consent rules.
+A consent rule (this is the worn garment consent rule):
 	If the noun is a garment (called G) and G is worn by someone:
 		Let P be the holder of G;
 		Unless the actor is the player:
@@ -3459,11 +3477,26 @@ A default-consent rule (this is the undressing consent rule):
 				Deny consent;
 	Give consent;
 
-A consent rule for an actor taking off something (this is the undressing default consent rule): Abide by the undressing consent rule;
-A consent rule for an actor taking a garment (this is the taking off default consent rule): Abide by the undressing consent rule;
-A consent rule for an actor ripping a garment (this is the ripping default consent rule): Abide by the undressing consent rule;
-A consent rule for an actor shifting a garment (this is the shifting default consent rule): Abide by the undressing consent rule;
-A consent rule for an actor unshifting a garment (this is the unshifting default consent rule): Abide by the undressing consent rule;
+A consent rule for an actor taking off something (this is the undressing default consent rule):
+	Unless DACS option is active, make no decision;
+	Abide by the love interest consent rule;
+	Abide by the worn garment consent rule;
+A consent rule for an actor taking a garment (this is the taking off default consent rule):
+	Unless DACS option is active, make no decision;
+	Abide by the love interest consent rule;
+	Abide by the worn garment consent rule;
+A consent rule for an actor ripping a garment (this is the ripping default consent rule):
+	Unless DACS option is active, make no decision;
+	Abide by the love interest consent rule;
+	Abide by the worn garment consent rule;
+A consent rule for an actor shifting a garment (this is the shifting default consent rule):
+	Unless DACS option is active, make no decision;
+	Abide by the love interest consent rule;
+	Abide by the worn garment consent rule;
+A consent rule for an actor unshifting a garment (this is the unshifting default consent rule):
+	Unless DACS option is active, make no decision;
+	Abide by the love interest consent rule;
+	Abide by the worn garment consent rule;
 
 Chapter 5.2.2c - Soft-play
 
@@ -3479,8 +3512,9 @@ A person has an arousal called the soft-play recipient limit. The soft-play reci
 A body part has an arousal called the soft-play performer limit. The soft-play performer limit of a body part is usually aroused.
 A body part has an arousal called the soft-play recipient limit. The soft-play recipient limit of a body part is usually aroused.
 
-[Create a default consent rule]
-A default-consent rule (this is the soft-playing consent rule):
+[Create a default soft-playing consent rule]
+The soft-playing consent rule is listed after the default consent rule in the consent rules.
+A consent rule (this is the soft-playing consent rule):
 	[Check consent for the actor first; we assume that the player always consent.]
 	Unless the actor is the player:
 		If the soft-play threshold of the actor is the unattainable arousal:
@@ -3515,15 +3549,34 @@ A default-consent rule (this is the soft-playing consent rule):
 				Deny consent;
 	Give consent;
 
-A consent rule for an actor touching (this is the default touching consent rule): Abide by the soft-playing consent rule;
-A consent rule for an actor rubbing (this is the default rubbing consent rule): Abide by the soft-playing consent rule;
-A consent rule for an actor tickling (this is the default tickling consent rule): Abide by the soft-playing consent rule;
-A consent rule for an actor kissing (this is the default kissing consent rule): Abide by the soft-playing consent rule;
-A consent rule for an actor hugging (this is the default hugging consent rule): Abide by the soft-playing consent rule;
-A consent rule for an actor dancing (this is the default dancing consent rule): Abide by the soft-playing consent rule;
+A consent rule for an actor touching (this is the default touching consent rule):
+	Unless DACS option is active, make no decision;
+	Abide by the love interest consent rule;
+	Abide by the soft-playing consent rule;
+A consent rule for an actor rubbing (this is the default rubbing consent rule):
+	Unless DACS option is active, make no decision;
+	Abide by the love interest consent rule;
+	Abide by the soft-playing consent rule;
+A consent rule for an actor tickling (this is the default tickling consent rule):
+	Unless DACS option is active, make no decision;
+	Abide by the love interest consent rule;
+	Abide by the soft-playing consent rule;
+A consent rule for an actor kissing (this is the default kissing consent rule):
+	Unless DACS option is active, make no decision;
+	Abide by the love interest consent rule;
+	Abide by the soft-playing consent rule;
+A consent rule for an actor hugging (this is the default hugging consent rule):
+	Unless DACS option is active, make no decision;
+	Abide by the love interest consent rule;
+	Abide by the soft-playing consent rule;
+A consent rule for an actor dancing (this is the default dancing consent rule):
+	Unless DACS option is active, make no decision;
+	Abide by the love interest consent rule;
+	Abide by the soft-playing consent rule;
 
 [Create a default stimulation rule]
-A default-stimulation rule (this is the soft-playing stimulation rule):
+The soft-playing stimulation rule is listed after the default stimulation rule in the stimulation rules.
+A stimulation rule (this is the soft-playing stimulation rule):
 	[Stimulate the actor first:]
 	Arouse the actor up to the soft-play performer limit of the actor;
 	If the noun is a person:
@@ -3536,12 +3589,24 @@ A default-stimulation rule (this is the soft-playing stimulation rule):
 		Arouse P up to target arousal;
 	Stimulated;
 
-A stimulation rule for an actor touching (this is the default touching stimulation rule): Abide by the soft-playing stimulation rule;
-A stimulation rule for an actor rubbing (this is the default rubbing stimulation rule): Abide by the soft-playing stimulation rule;
-A stimulation rule for an actor tickling (this is the default tickling stimulation rule): Abide by the soft-playing stimulation rule;
-A stimulation rule for an actor kissing (this is the default kissing stimulation rule): Abide by the soft-playing stimulation rule;
-A stimulation rule for an actor hugging (this is the default hugging stimulation rule): Abide by the soft-playing stimulation rule;
-A stimulation rule for an actor dancing (this is the default dancing stimulation rule): Abide by the soft-playing stimulation rule;
+A stimulation rule for an actor touching (this is the default touching stimulation rule):
+	Unless DACS option is active, make no decision;
+	Abide by the soft-playing stimulation rule;
+A stimulation rule for an actor rubbing (this is the default rubbing stimulation rule):
+	Unless DACS option is active, make no decision;
+	Abide by the soft-playing stimulation rule;
+A stimulation rule for an actor tickling (this is the default tickling stimulation rule):
+	Unless DACS option is active, make no decision;
+	Abide by the soft-playing stimulation rule;
+A stimulation rule for an actor kissing (this is the default kissing stimulation rule):
+	Unless DACS option is active, make no decision;
+	Abide by the soft-playing stimulation rule;
+A stimulation rule for an actor hugging (this is the default hugging stimulation rule):
+	Unless DACS option is active, make no decision;
+	Abide by the soft-playing stimulation rule;
+A stimulation rule for an actor dancing (this is the default dancing stimulation rule):
+	Unless DACS option is active, make no decision;
+	Abide by the soft-playing stimulation rule;
 
 Chapter 5.2.2d - Rough Play
 
@@ -3558,7 +3623,8 @@ A body part has an arousal called the rough-play performer limit. The rough-play
 A body part has an arousal called the rough-play recipient limit. The rough-play recipient limit of a body part is usually very aroused.
 
 [Create a default consent rule]
-A default-consent rule (this is the rough-playing consent rule):
+The rough-playing consent rule is listed after the default consent rule in the consent rules.
+A consent rule (this is the rough-playing consent rule):
 	[Check consent for the actor first; we assume that the player always consent.]
 	Unless the actor is the player:
 		If the rough-play threshold of the actor is the unattainable arousal:
@@ -3593,12 +3659,22 @@ A default-consent rule (this is the rough-playing consent rule):
 				Deny consent;
 	Give consent;
 
-A consent rule for an actor spanking (this is the default spanking consent rule): Abide by the rough-playing consent rule;
-A consent rule for an actor pinching (this is the default pinching consent rule): Abide by the rough-playing consent rule;
-A consent rule for an actor biting (this is the default biting consent rule): Abide by the rough-playing consent rule;
+A consent rule for an actor spanking (this is the default spanking consent rule):
+	Unless DACS option is active, make no decision;
+	Abide by the love interest consent rule;
+	Abide by the rough-playing consent rule;
+A consent rule for an actor pinching (this is the default pinching consent rule):
+	Unless DACS option is active, make no decision;
+	Abide by the love interest consent rule;
+	Abide by the rough-playing consent rule;
+A consent rule for an actor biting (this is the default biting consent rule):
+	Unless DACS option is active, make no decision;
+	Abide by the love interest consent rule;
+	Abide by the rough-playing consent rule;
 
 [Create a default stimulation rule]
-A default-stimulation rule (this is the rough-playing stimulation rule):
+The rough-playing stimulation rule is listed after the default stimulation rule in the stimulation rules.
+A stimulation rule (this is the rough-playing stimulation rule):
 	[Stimulate the actor first:]
 	Arouse the actor up to the rough-play performer limit of the actor;
 	If the noun is a person:
@@ -3611,9 +3687,15 @@ A default-stimulation rule (this is the rough-playing stimulation rule):
 		Arouse P up to target arousal;
 	Stimulated;
 
-A stimulation rule for an actor spanking (this is the default spanking stimulation rule): Abide by the rough-playing stimulation rule;
-A stimulation rule for an actor pinching (this is the default pinching stimulation rule): Abide by the rough-playing stimulation rule;
-A stimulation rule for an actor biting (this is the default biting stimulation rule): Abide by the rough-playing stimulation rule;
+A stimulation rule for an actor spanking (this is the default spanking stimulation rule):
+	Unless DACS option is active, make no decision;
+	Abide by the rough-playing stimulation rule;
+A stimulation rule for an actor pinching (this is the default pinching stimulation rule):
+	Unless DACS option is active, make no decision;
+	Abide by the rough-playing stimulation rule;
+A stimulation rule for an actor biting (this is the default biting stimulation rule):
+	Unless DACS option is active, make no decision;
+	Abide by the rough-playing stimulation rule;
 
 Chapter 5.2.2e - Oral Play
 
@@ -3630,7 +3712,8 @@ A body part has an arousal called the oral-play performer limit. The oral-play p
 A body part has an arousal called the oral-play recipient limit. The oral-play recipient limit of a body part is usually very aroused.
 
 [Create a default consent rule]
-A default-consent rule (this is the oral-playing consent rule):
+The oral-playing consent rule is listed after the default consent rule in the consent rules.
+A consent rule (this is the oral-playing consent rule):
 	[Check consent for the actor first; we assume that the player always consent.]
 	Unless the actor is the player:
 		If the oral-play threshold of the actor is the unattainable arousal:
@@ -3665,10 +3748,14 @@ A default-consent rule (this is the oral-playing consent rule):
 				Deny consent;
 	Give consent;
 
-A consent rule for an actor licking (this is the default licking consent rule): Abide by the oral-playing consent rule;
+A consent rule for an actor licking (this is the default licking consent rule):
+	Unless DACS option is active, make no decision;
+	Abide by the love interest consent rule;
+	Abide by the oral-playing consent rule;
 
 [Create a default stimulation rule]
-A default-stimulation rule (this is the oral-playing stimulation rule):
+The oral-playing stimulation rule is listed after the default stimulation rule in the stimulation rules.
+A stimulation rule (this is the oral-playing stimulation rule):
 	[Stimulate the actor first:]
 	Arouse the actor up to the oral-play performer limit of the actor;
 	If the noun is a person:
@@ -3681,7 +3768,9 @@ A default-stimulation rule (this is the oral-playing stimulation rule):
 		Arouse P up to target arousal;
 	Stimulated;
 
-A stimulation rule for an actor licking (this is the default licking stimulation rule): Abide by the oral-playing stimulation rule;
+A stimulation rule for an actor licking (this is the default licking stimulation rule):
+	Unless DACS option is active, make no decision;
+	Abide by the oral-playing stimulation rule;
 
 Chapter 5.2.2f - Fucking
 
@@ -3699,7 +3788,8 @@ A body part has an arousal called the fuck-play recipient limit. The fuck-play r
 
 [Create a default consent rule:
 Due to prior checks, we assume that the actor is enclosing one of the nouns, so we only check consent for the controller of each noun:]
-A default-consent rule (this is the fuck-playing consent rule):
+The fuck-playing consent rule is listed after the default consent rule in the consent rules.
+A consent rule (this is the fuck-playing consent rule):
 	If the noun is a body part:
 		Let P be the holder of the noun;
 		Unless P is the player:
@@ -3750,12 +3840,16 @@ A default-consent rule (this is the fuck-playing consent rule):
 				Deny consent;
 	Give consent;
 
-A consent rule for an actor fucking something with (this is the default fucking consent rule): Abide by the fuck-playing consent rule;
+A consent rule for an actor fucking something with (this is the default fucking consent rule):
+	Unless DACS option is active, make no decision;
+	Abide by the love interest consent rule;
+	Abide by the fuck-playing consent rule;
 
 [Create a default stimulation rule:
 Due to prior checks, we assume that the actor is enclosing one of the nouns, so we don't stimulate the actor directly.
 We do need to make sure we don't stimulate a self-pleasuring actor twice.]
-A default-stimulation rule (this is the fuck-playing stimulation rule):
+The fuck-playing stimulation rule is listed after the default stimulation rule in the stimulation rules.
+A stimulation rule (this is the fuck-playing stimulation rule):
 	Let actor-stimulation be false;
 	If the noun is a body part:
 		Let P be the holder of the noun;
@@ -3801,7 +3895,9 @@ A default-stimulation rule (this is the fuck-playing stimulation rule):
 			Arouse P up to the fuck-play recipient limit of P;
 	Stimulated;
 
-A stimulation rule for an actor fucking something with (this is the default fucking stimulation rule): Abide by the fuck-playing stimulation rule;
+A stimulation rule for an actor fucking something with (this is the default fucking stimulation rule):
+	Unless DACS option is active, make no decision;
+	Abide by the fuck-playing stimulation rule;
 
 Part 5.2.3 - Body Part Integration
 


### PR DESCRIPTION
Made DACS truly optional, and removed the default rulebooks for consent and stimulation.
Net effect should be no real changes, but it's safer and more as intended.
