### PR TITLE
Prevent two items at the same layer being worn together.

### DIFF
--- a/Erotic Storytelling.i7x
+++ b/Erotic Storytelling.i7x
@@ -555,7 +555,7 @@ To decide whether (G - a garment) can be worn by (P - a person):
 	Sort clothing in reverse clothing layer order;
 	Repeat with A running through cover:
 		Repeat with cloth running through clothing:
-			If clothing layer of cloth is greater than clothing layer of G:
+			If clothing layer of cloth >= clothing layer of G:
 				If A is listed in the modified cover areas of cloth, decide no;
 	Decide yes;
 	
@@ -568,7 +568,7 @@ To decide which list of garments is preventing wearing of (G - a garment) by (P 
 	Sort clothing in reverse clothing layer order;
 	Repeat with A running through cover:
 		Repeat with cloth running through clothing:
-			If clothing layer of cloth is greater than clothing layer of G:
+			If clothing layer of cloth >= clothing layer of G:
 				If A is listed in modified cover areas of cloth:
 					Add cloth to preventers, if absent;
 	Decide on preventers;


### PR DESCRIPTION
  eg. two pairs of trousers; or two dresses.

It seems reasonable to stop the player being able to wear tow items at the same layer together, in my test game I was able wear two dresses at the same time and (more reasonably) a dress and a pair of trousers.
This changes prevents both of the above cases. If the later case is needed , more layers is the most reasonable solution - perhaps a intermediate layer for each is required; or a just_above_LAYER; and just_below_LAYER - although that complicates things immensely.