### PR TITLE
Minidress Changes - Hopefully fixes.

### DIFF
--- a/Erotic Storytelling.i7x
+++ b/Erotic Storytelling.i7x
@@ -3455,6 +3455,13 @@ Some glasses is usually normalwear.
 The cloth decency of some glasses is usually formal.
 The cover areas of some glasses is usually {face area}.
 
+A minidress is a kind of garment.
+The specification of a minidress is "A minidress is a short dress that doesn't cover the legs; see dress for more details. It's usually casual and normalwear. It's can usually be raised to gain access to the crotch."
+A minidress is usually normalwear.
+The cloth decency of minidress is usually immodest.
+The cover areas of a minidress is usually {shoulder area, arm area, upper torso area, lower torso area, upper back area, lower back area, crotch area, thigh area}.
+A minidress is usually shiftable. The shiftyness of a minidress is usually raisable. The shifting revealed cover areas of a minidress is usually {crotch area, thigh area}.
+
 Chapter 5.1.2c - Overwear
 
 [Overwear is the outer layer of clothing, and is only covered by outerwear (clothing that is meant for outside use).]
@@ -3467,13 +3474,6 @@ The cloth decency of dress is usually casual.
 The cover areas of a dress is usually {shoulder area, arm area, upper torso area, lower torso area, upper back area, lower back area, crotch area, thigh area, leg area}.
 A dress is usually default cover blocking.
 A dress is usually shiftable. The shiftyness of a dress is usually buttonable. The shifting revealed cover areas of a dress is usually {shoulder area, upper torso area, lower torso area}.
-
-A minidress is a kind of garment.
-The specification of a minidress is "A minidress is a short dress that doesn't cover the legs; see dress for more details. It's usually casual and normalwear. It's can usually be raised to gain access to the crotch."
-A minidress is usually overwear.
-The cloth decency of minidress is usually immodest.
-The cover areas of a minidress is usually {shoulder area, arm area, upper torso area, lower torso area, upper back area, lower back area, crotch area, thigh area}.
-A minidress is usually shiftable. The shiftyness of a dress is usually raisable. The shifting revealed cover areas of a dress is usually {crotch area, thigh area}.
 
 Some trousers is a kind of garment.
 It is usually ambiguously plural. The indefinite article is usually "some". The plural of some trousers is pairs of trousers.

--- a/Erotic Storytelling.i7x
+++ b/Erotic Storytelling.i7x
@@ -555,7 +555,7 @@ To decide whether (G - a garment) can be worn by (P - a person):
 	Sort clothing in reverse clothing layer order;
 	Repeat with A running through cover:
 		Repeat with cloth running through clothing:
-			If clothing layer of cloth is greater than clothing layer of G:
+			If clothing layer of cloth >= clothing layer of G:
 				If A is listed in the modified cover areas of cloth, decide no;
 	Decide yes;
 	
@@ -568,7 +568,7 @@ To decide which list of garments is preventing wearing of (G - a garment) by (P 
 	Sort clothing in reverse clothing layer order;
 	Repeat with A running through cover:
 		Repeat with cloth running through clothing:
-			If clothing layer of cloth is greater than clothing layer of G:
+			If clothing layer of cloth >= clothing layer of G:
 				If A is listed in modified cover areas of cloth:
 					Add cloth to preventers, if absent;
 	Decide on preventers;


### PR DESCRIPTION
I've spotted what look like copy and past mistakes in minidress. The specification says it is normalwear but the code says outerwear. Also the shiftyness spec was coded for the dress so it was overriding the ealier stanza and leaving those properties undefined on minidreses. 

Also moved minidress in the the normalwear section from outerwear.